### PR TITLE
update MessageTemplates to use BackdropTemplate

### DIFF
--- a/MessageTemplates/MessageTemplates.xml
+++ b/MessageTemplates/MessageTemplates.xml
@@ -1,18 +1,11 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+<Ui xmlns="http://www.blizzard.com/wow/ui/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
 	<Script file="MessageTemplates/MessageTemplates.lua"/>
-	<Frame name="MessageTemplate" virtual="true" mixin="MessageTemplateMixin">
-		<Backdrop bgFile="Interface\TutorialFrame\TutorialFrameBackground" tile="true" alphaMode="BLEND">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="16"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="5" right="5" top="5" bottom="5"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="MessageTemplate" virtual="true" mixin="MessageTemplateMixin" inherits="BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="BACKDROP_TUTORIAL_16_16" type="global" />
+		</KeyValues>
 	</Frame>
 	<Include file="MessageTemplates/BasicMessageTemplate.xml"/>
 	<Include file="MessageTemplates/SaleMessageTemplate.xml"/>


### PR DESCRIPTION
Old backdropInfo has been removed and BACKDROP_TUTORIAL_16_16 seems close enough to the original values.
Should fix some of the errors in #24 